### PR TITLE
Use start/end anchors in matchStrings() regex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require": {
         "php": ">=5.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4|^5|^6|^7|^8|^9"
+    },
     "autoload": {
         "psr-0": { "dflydev\\util\\antPathMatcher": "src" }
     }

--- a/src/dflydev/util/antPathMatcher/AntPathMatcher.php
+++ b/src/dflydev/util/antPathMatcher/AntPathMatcher.php
@@ -221,7 +221,7 @@ class AntPathMatcher implements IAntPathMatcher
     {
         $re = preg_replace_callback('([\?\*\.\+])', array($this, 'matchStringsCallback'), $pattern);
 
-        return preg_match('/'.$re.'/', $str);
+        return preg_match('/^'.$re.'$/', $str);
     }
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,3 +10,7 @@
 
 $loader = require dirname(__DIR__).'/vendor/autoload.php';
 $loader->add('dflydev\\tests\\util\\antPathMatcher', 'tests');
+
+if (class_exists('PHPUnit\Framework\TestCase') && ! class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}

--- a/tests/dflydev/tests/util/antPathMatcher/AntPathMatcherTest.php
+++ b/tests/dflydev/tests/util/antPathMatcher/AntPathMatcherTest.php
@@ -30,7 +30,7 @@ class AntPathMatcherTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider testMatchesProvider
+     * @dataProvider provideMatches
      */
     public function testMatches($pattern, $shouldMatch, $shouldNotMatch)
     {
@@ -48,7 +48,7 @@ class AntPathMatcherTest extends \PHPUnit_Framework_TestCase
         return 'Testing path "' . $path . '" against pattern "' . $pattern . '"';
     }
 
-    public function testMatchesProvider()
+    public function provideMatches()
     {
         return array(
             array(

--- a/tests/dflydev/tests/util/antPathMatcher/AntPathMatcherTest.php
+++ b/tests/dflydev/tests/util/antPathMatcher/AntPathMatcherTest.php
@@ -53,6 +53,11 @@ class AntPathMatcherTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 'com/t?st',
+                array('com/test', 'com/tast', 'com/txst'),
+                array('com/test.jsp', 'com/tast.jsp', 'com/txst.jsp'),
+            ),
+            array(
+                'com/t?st.jsp',
                 array('com/test.jsp', 'com/tast.jsp', 'com/txst.jsp'),
                 array('com/toast.jsp', 'com/README.md')
             ),
@@ -95,7 +100,12 @@ class AntPathMatcherTest extends \PHPUnit_Framework_TestCase
                 'com/foo/',
                 array('com/foo/bar.jsp','com/foo/bar/baz.jsp',),
                 array('com.txt', 'com/foo.txt'),
-            )
+            ),
+            array(
+                'com/**',
+                array('com/foo'),
+                array('com2/foo', '_com/foo'),
+            ),
         );
     }
     


### PR DESCRIPTION
I came across this when creating two similarly named collections in a Sculpin deployment ("posts" and "posts2" used source directories "_posts" and "_posts2", respectively). I found that the data collector for "posts" contained sources from _both_ directories and ultimately traced it back to logic in AntPathMatcherTest.

I wasn't familiar with the Ant pattern syntax before this PR, but I think the regex anchoring is correct per the syntax definition in [AntPathMatcher](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html) in the Spring API docs. I didn't come across any documentation that suggested path components should _not_ be matched in their entirety. That said, `matchStrings()` is called from a few places so it'd be prudent to confirm this doesn't inadvertently break other use cases.

In order to test this, I had to make some additional changes to allow a newer version of PHPUnit. I attempted to do so without breaking support for older PHP versions.

As a side note, if you're looking to improve the test coverage for the AntPathMatcher class, it may be worth pulling in additional test cases from [AntPathMatcherTests.java](https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/test/java/org/springframework/util/AntPathMatcherTests.java).
